### PR TITLE
Fix spurious exit on speech interruption by espeakup

### DIFF
--- a/Parser/input_file.c
+++ b/Parser/input_file.c
@@ -23,6 +23,7 @@
  * 22/06/98 : Created
  */
 
+#include <errno.h>
 #include "mbralloc.h"
 #include "input_file.h"
 
@@ -33,7 +34,13 @@
 
 static long readline_InputFile(Input* in, char *line, int size)
 {
-	return( (long) fgets(line, size, (FILE*)in->self));
+	char *ret;
+
+	do
+		ret = fgets(line, size, (FILE*)in->self);
+	while (ret == NULL && errno == EINTR);
+
+	return ret != NULL;
 }
 
 static void reset_InputFile(Input* in)


### PR DESCRIPTION
espeak sends SIGUSR1 to make mbrola flush its output. Handling that signal
however makes fgets return EINTR, as expected on System V systems.
readline_InputFile thus has to loop over in that case. Otherwise it
would erroneously think an error or EOF occurred and exit.