### PR TITLE
separate CC from CFLAGS

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,12 +4,13 @@
 VERSION=3.4-dev
 
 # To test strict C ANSI compliance
-CC = gcc -ansi -pedantic
+CC = gcc
+CFLAGS += -ansi -pedantic
 LIB= -lm
 
 # This allow you to write commands like "make PURE=purify demo1"
 # or "make PURE=quantify lib2"
-CCPURE = $(PURE) $(CC)
+CCPURE = $(PURE) $(CC) $(CFLAGS)
 
 ########################
 # Machine specific #define, uncomment as needed


### PR DESCRIPTION
this change allows to specify CC and CFLAGS separate from each other ; one might use clang or ccache instead of gcc, but not lose the parameters "-ansi -pedantic" ; it also allows for specifying a custom initial value for CFLAGS ( for example "-fstack-protector-strong -Wformat -Werror=format-security" as arch linux does ).