### PR TITLE
Fix detecting EOF

### DIFF
--- a/Parser/input_file.c
+++ b/Parser/input_file.c
@@ -38,7 +38,7 @@ static long readline_InputFile(Input* in, char *line, int size)
 
 	do
 		ret = fgets(line, size, (FILE*)in->self);
-	while (ret == NULL && errno == EINTR);
+	while (ret == NULL && !feof((FILE*)in->self) && errno == EINTR);
 
 	return ret != NULL;
 }


### PR DESCRIPTION
fgets returns NULL on EOF as well, so we need to call feof to properly
detect EOF.
