### PR TITLE
Fix parallel build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -146,7 +146,7 @@ tags:
 net:
 	\rm -f *~ */*~
 
-$(BINDIR)/%.o: %.c
+$(BINDIR)/%.o: %.c install_dir
 	$(CCPURE) $(CPPFLAGS) $(CFLAGS) -o $@ -c $<
 
 # to create the compilation directory, if necessary


### PR DESCRIPTION
BINDIR is created by the install_dir rule, so the rule creating files
there must depend on it.