### PR TITLE
NetBSD support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -25,7 +25,7 @@ CCPURE = $(PURE) $(CC)
 
 # If endianess of your machine is not automatically detected in Misc/common.h
 # you should manually specify here
-CFLAGS += -DLITTLE_ENDIAN
+#CFLAGS += -DLITTLE_ENDIAN
 #CFLAGS += -DBIG_ENDIAN
 
 #######################

--- a/Misc/common.h
+++ b/Misc/common.h
@@ -76,11 +76,11 @@ void swab( const char *from, char *to, int nbytes);
 #endif
 #endif
 
-#if defined(__GLIBC__)
+#if defined(__GLIBC__) || defined(__NetBSD__)
 #include <endian.h>
 #undef BIG_ENDIAN
 #undef LITTLE_ENDIAN
-#if __BYTE_ORDER == __LITTLE_ENDIAN
+#if __BYTE_ORDER == __LITTLE_ENDIAN || _BYTE_ORDER == _LITTLE_ENDIAN
 #  define LITTLE_ENDIAN
 #else
 #  define BIG_ENDIAN


### PR DESCRIPTION
This adds NetBSD auto-detection for the endianness support, and removes the assumption that everything is little-endian from the main Makefile.
This addresses #43 and is based on @adr-adr's  work.