### PR TITLE
Fix cross-builds

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,8 @@
 # Mbrola Speech Synthesize Makefile ( tune the #define and type "make" )
 VERSION=3.4-dev
 
-CC ?= gcc -ansi -pedantic
+CC ?= gcc
+CFLAGS += -ansi -pedantic
 LIB= -lm
 
 # This allow you to write commands like "make PURE=purify demo1"


### PR DESCRIPTION
Cross-building infrastructures would set CC, and thus lose the -ansi option, which is required to have __STRICT_ANSI__ defined and thus notably the internal swab function used.